### PR TITLE
docs: refresh README and add docs/README.md paperwork index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,183 @@
-﻿# Sentinel-of-sentinel-s-Forge
+# Sentinel Forge Cognitive AI Orchestration Platform
 
-**AI that processes information using diverse cognitive patterns**
+![CI](https://github.com/coconuthead-Sentinel-core/sentinel-forge-cognitive-orchestrator/workflows/Python%20application/badge.svg)
 
-An enterprise-grade cognitive architecture that processes information using diverse processing modes - making AI systems accessible to diverse thinkers instead of assuming everyone thinks the same way.
+Neurodivergent-aware cognitive orchestration for FastAPI-based chat, symbolic routing, adaptive presentation lenses, and real-time cognitive state streaming.
 
-## ðŸŽ¯ What It Does
+## Mission
+Build an AI orchestration layer that can adapt its output to different cognitive processing styles while keeping the runtime observable, testable, and safe to extend.
 
-Traditional AI assumes everyone thinks the same way. This framework includes specialized processing modes for:
+## Current Status
+- Local validation is green.
+- `python -m pytest -q`: `152 passed`
+- `python scripts/smoke_test.py`: passed on `2026-04-22`
+- Mock AI mode and mock Cosmos persistence both work for local development.
+- Azure-backed identity and live model scoring remain optional integrations.
+- Engineering-build, SDLC, governance, security, and iOS compliance paperwork packets are now routed through `docs/README.md`.
 
-- **Rapid Context-Switching Processing Mode:** Rapid context-switching and dynamic bursts
-- **Precision Pattern Recognition Processing Mode:** Precision pattern recognition and detail focus  
-- **Multi-dimensional Symbol Interpretation Processing Mode:** Multi-dimensional symbol interpretation
-- **Alternative Mathematical Reasoning Processing Mode:** Alternative mathematical reasoning
+## Architecture
+The current codebase is broader than the original published README. The verified runtime centers on these components:
 
-**The Result:** AI systems that adapt to how YOU think, not the other way around.
+- `backend/main.py`: FastAPI app bootstrap and router wiring.
+- `backend/api.py`: REST endpoints for chat, cognition, glyphs, sync, dashboard, status, jobs, profiles, and operational views.
+- `backend/ws_api.py`: WebSocket streams for compatibility sync, cognitive events, and metrics.
+- `backend/services/cognitive_orchestrator.py`: Main adaptive processing layer built on `ChatService`, three-zone memory, symbolic metadata, and lens transforms.
+- `backend/services/adhd_lens.py`: Chunked, action-oriented formatting.
+- `backend/services/autism_lens.py`: Structured detail extraction, definitions, and explicit sectioning.
+- `backend/services/dyslexia_lens.py`: Spatial map formatting for visually anchored summaries.
+- `backend/services/glyph_processor.py`: Symbolic seed matching and metadata generation.
+- `backend/services/glyph_event_bridge.py`: EventBus publication for glyph-driven routing.
+- `backend/services/quantum_nexus.py`: Lattice coordinate and dependency resolver used by tests and symbolic workflows.
+- `backend/eventbus.py`: In-process event transport for dashboards and WebSockets.
+- `backend/infrastructure/cosmos_repo.py`: Cosmos DB repository with mock fallback support for local runs.
+- `quantum_nexus_forge_v5_2_enhanced.py` and related top-level modules: lower-level forge/runtime primitives used by orchestration and simulation flows.
 
-## ðŸ’¡ Why It Matters
+## Project Layout
+```text
+sentinel-forge-cognitive-orchestrator/
+|-- backend/
+|   |-- api.py
+|   |-- main.py
+|   |-- ws_api.py
+|   |-- eventbus.py
+|   |-- services/
+|   |-- infrastructure/
+|   `-- adapters/
+|-- data/
+|-- docs/
+|-- evaluation/
+|-- frontend/
+|-- scripts/
+|-- static/
+|-- templates/
+|-- tests/
+|-- README.md
+|-- requirements.txt
+|-- Dockerfile
+`-- docker-compose.yml
+```
 
-Most AI tools ignore this entirely, creating accessibility barriers. This framework proves AI can be built inclusively from the ground[...]
+## Quick Start
+### Prerequisites
+- Python 3.11+
+- Optional Azure OpenAI and Cosmos DB credentials if you want live cloud integrations
 
-**Potential Applications:** 
-- Accessible knowledge management systems
-- Cognitive-diversity-aware AI assistants  
-- Enterprise tools for diverse teams
-- Research into computational models of different thinking styles
+### Install
+```powershell
+python -m venv .venv
+.\.venv\Scripts\pip install -r requirements.txt
+```
 
-## ðŸš€ Tech Stack
+### Local development
+```powershell
+$env:MOCK_AI = "true"
+uvicorn backend.main:app --reload --port 8000
+```
 
-- **Language:** Python 3.11+
-- **Architecture:** Object-oriented with dataclasses and type hints
-- **Key Features:** Three-zone memory system, symbolic processing, real-time performance monitoring
-- **Code Quality:** 1000+ lines, fully typed, production-ready
+### Verify the build
+```powershell
+.\.venv\Scripts\python.exe scripts\smoke_test.py
+.\.venv\Scripts\python.exe -m pytest -q
+```
 
-## ðŸ“¦ Quick Start
+## Basic Usage
+```python
+import asyncio
+
+from backend.mock_adapter import MockOpenAIAdapter
+from backend.services.cognitive_orchestrator import create_orchestrator
+
+
+async def main():
+    orchestrator = create_orchestrator(MockOpenAIAdapter(), lens="adhd")
+    result = await orchestrator.process_message("Explain how glyph routing works.")
+    print(result["choices"][0]["message"]["content"])
+
+
+asyncio.run(main())
+```
+
+## Verified API Surface
+### REST endpoints
+- `GET /api/status`
+- `GET /api/metrics`
+- `GET /api/healthz`
+- `GET /api/readyz`
+- `GET /api/version`
+- `POST /api/chat`
+- `POST /api/glyphs/interpret`
+- `POST /api/glyphs/pack`
+- `POST /api/glyphs/validate`
+- `POST /api/cog/process`
+- `GET /api/cog/status`
+- `POST /api/activate/{preset}`
+- `POST /api/sync/update`
+- `GET /api/sync/snapshot`
+- `GET /api/sync/trinode`
+- `POST /api/notes/upsert`
+
+### WebSocket endpoints
+- `/ws/sync`: compatibility stream for raw EventBus forwarding
+- `/ws/cognitive`: cognitive and symbolic event stream with initial state snapshot
+- `/ws/metrics`: real-time metrics event stream
+
+## Testing
+The current automated coverage includes:
+- cognitive lens formatting and integration behavior
+- glyph loading, fuzzy matching, and bridge emission
+- quantum nexus coordinate resolution and dependency tracing
+- WebSocket event streaming
+- EventBus delivery behavior
+- firewall output constraints
+- orchestrator symbolic reaction flow
+
+Run the full suite with:
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q
+```
+
+## Configuration
+### Core environment variables
 ```bash
-# Clone the repository
-git clone https://github.com/coconuthead-Sentinel-core/Sentinel-of-sentinel-s-Forge.git
-cd Sentinel-of-sentinel-s-Forge
-
-# Install dependencies  
-pip install -r requirements.txt
-
-# Run the demo
-python quantum_nexus_forge_v5_2_enhanced.py
+MOCK_AI=true
+AOAI_ENDPOINT=https://your-endpoint.openai.azure.com/
+API_KEY=your-guard-key
+COSMOS_ENDPOINT=https://your-account.documents.azure.com/
+COSMOS_KEY=your-key
+PYTHONPATH=/path/to/project
 ```
 
-## âœ¨ Core Features
+### Runtime notes
+- If Azure credentials are absent, local development can still run in mock mode.
+- Cosmos persistence falls back to a mock repository in local validation flows.
+- Some startup paths still emit FastAPI deprecation warnings around `on_event`; these are warnings, not current test blockers.
 
-### Three-Zone Memory System
-- **ðŸŸ¢ Active Processing:** High-entropy real-time data (>0.7 entropy)
-- **ðŸŸ¡ Pattern Emergence:** Mid-entropy pattern recognition (0.3-0.7 entropy)
-- **ðŸ”´ Crystallized Storage:** Low-entropy stable memory (<0.3 entropy)
+## Roadmap
+### Completed
+- Adaptive cognitive lenses
+- Three-zone memory routing
+- Symbolic glyph processing
+- WebSocket state and metrics streams
+- Smoke-testable local development workflow
+- Passing automated validation suite
 
-### Specialized Processing Modes
-- Precision pattern recognition modes
-- Dynamic burst processing modes
-- Multi-dimensional symbol interpretation modes
-- Alternative mathematical reasoning modes
-- Standard baseline (for comparison)
+### In progress
+- Azure live scoring integration
+- deployment hardening and release packaging
+- broader documentation cleanup across legacy top-level artifacts
 
-### Advanced Capabilities
-- **Symbolic Stream Processing:** Interpret emoji sequences as cognitive operations
-- **Performance Monitoring:** Real-time metrics and system health tracking
-- **Spatial Cognition:** 3D coordinate system with cognitive elevation
-- **Geometric Primitives:** Tetrahedron, Cube, Octahedron, Dodecahedron, Icosahedron
+### Future
+- additional cognitive lens contributions
+- stronger dashboard and observability surfaces
+- mobile and voice-facing clients
+- research and enterprise integration layers
 
-## ðŸ“ Project Structure
-```
-Sentinel-of-sentinel-s-Forge/
-â”œâ”€â”€ quantum_nexus_forge_v5_2_enhanced.py  # Main cognitive architecture
-â”œâ”€â”€ demo.py                                # Demonstration script
-â”œâ”€â”€ requirements.txt                       # Python dependencies
-â”œâ”€â”€ __init__.py                            # Package initialization
-â””â”€â”€ README.md                              # This file
-```
+## Contributing
+1. Fork the repository.
+2. Create a branch.
+3. Install dependencies.
+4. Run `python -m pytest -q`.
+5. Submit a pull request with clear validation notes.
 
-## ðŸ‘¤ Author
-
-**Shannon Bryan Kelly**  
-*Neurodivergent AI Architect*
-
-Built in collaboration with Claude AI (Anthropic)
-
-## ðŸ“Š Status
-
-**Production-Ready** | **Version:** 5.2.0 | **Last Updated:** November 2025
-
----
-
-*Making AI accessible to all cognitive styles, one framework at a time.* ðŸ§ âœ¨
+## License
+MIT License. See `LICENSE`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,116 @@
+# Sentinel Forge — Paperwork Index
+
+This is the single routing point for every non-code artifact in the Sentinel
+Forge repository. The top-level `README.md` points here for the full
+engineering-build, SDLC, governance, security, legal, and iOS-track paperwork
+packets.
+
+If something is missing from this index, it is not considered "finished" — add
+the document in the right section and link it here.
+
+---
+
+## 1. Engineering-build and operations
+
+| Document | Purpose |
+| --- | --- |
+| [`QUICKSTART.md`](QUICKSTART.md) | Minimal local bring-up. |
+| [`USER_GUIDE.md`](USER_GUIDE.md) | End-user walk-through of the chat / cognition flows. |
+| [`API.md`](API.md) | Narrative REST + WebSocket surface. |
+| [`API_EXAMPLES.md`](API_EXAMPLES.md) | Runnable client snippets for the API surface. |
+| [`env_setup.md`](env_setup.md) | Environment variables, secrets, and local mock mode. |
+| [`AUTOMATION_OPERATIONS.md`](AUTOMATION_OPERATIONS.md) | Background jobs, schedulers, and operational scripts. |
+| [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) | Known-failure first-aid guide. |
+| [`RELEASE_PIPELINE.md`](RELEASE_PIPELINE.md) | Release workflow, registry variables, and deploy-time secrets. |
+| [`GIT_WORKFLOW.md`](GIT_WORKFLOW.md) | Branch / commit / review conventions. |
+| [`PARTNER_ENV_EXECUTION_CHECKLIST.md`](PARTNER_ENV_EXECUTION_CHECKLIST.md) | Partner-environment runbook. |
+| [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md) | Third-party software attributions. |
+| [`ROADMAP.md`](ROADMAP.md) | Forward-looking work tracked alongside the README roadmap. |
+| [`examples/dashboard.py`](examples/dashboard.py) | Example dashboard client. |
+
+## 2. SDLC packet (`docs/sdlc/`)
+
+Phase-tagged artifacts (`P1-…` through `P9-…`) so every SDLC stage has an
+owned, dated document.
+
+| Document | Purpose |
+| --- | --- |
+| [`sdlc/P1-CHARTER-001.md`](sdlc/P1-CHARTER-001.md) | Project charter. |
+| [`sdlc/P1-BIZCASE-002.md`](sdlc/P1-BIZCASE-002.md) | Business case. |
+| [`sdlc/P1-FEAS-003.md`](sdlc/P1-FEAS-003.md) | Feasibility study. |
+| [`sdlc/P1-SOW-004.md`](sdlc/P1-SOW-004.md) | Statement of work. |
+| [`sdlc/P1-STAKE-005.md`](sdlc/P1-STAKE-005.md) | Stakeholder register. |
+| [`sdlc/P1-RACI-006.md`](sdlc/P1-RACI-006.md) | RACI matrix. |
+| [`sdlc/P1-VISION-008.md`](sdlc/P1-VISION-008.md) | Product vision. |
+| [`sdlc/PRD.md`](sdlc/PRD.md) | Product requirements. |
+| [`sdlc/SYSTEM_DESIGN.md`](sdlc/SYSTEM_DESIGN.md) | System design. |
+| [`sdlc/API_CONTRACTS.md`](sdlc/API_CONTRACTS.md) | API contracts. |
+| [`sdlc/BACKLOG.md`](sdlc/BACKLOG.md) | Backlog of tracked work. |
+| [`sdlc/TEST_STRATEGY.md`](sdlc/TEST_STRATEGY.md) | Test strategy. |
+| [`sdlc/P9-ACCEPT-076.md`](sdlc/P9-ACCEPT-076.md) | Acceptance sign-off. |
+| [`sdlc/P9-TRANS-077.md`](sdlc/P9-TRANS-077.md) | Transition to operations. |
+| [`sdlc/P9-MAINT-078.md`](sdlc/P9-MAINT-078.md) | Maintenance plan. |
+| [`sdlc/P9-PIR-079.md`](sdlc/P9-PIR-079.md) | Post-implementation review. |
+| [`sdlc/P9-DRP-080.md`](sdlc/P9-DRP-080.md) | Disaster recovery plan. |
+| [`sdlc/P9-PROOF-LEDGER-081.md`](sdlc/P9-PROOF-LEDGER-081.md) | Proof-of-delivery ledger. |
+| [`sdlc/P9-CLOSE-075.md`](sdlc/P9-CLOSE-075.md) | Project closure record. |
+| [`SDLC_TOOLS_SKILLS_BLUEPRINT.md`](SDLC_TOOLS_SKILLS_BLUEPRINT.md) | Tools + skills blueprint covering the SDLC. |
+
+## 3. Governance, security, and compliance (`docs/compliance/`)
+
+| Document | Purpose |
+| --- | --- |
+| [`compliance/AI_POLICY.md`](compliance/AI_POLICY.md) | Organisational AI usage policy. |
+| [`compliance/INFORMATION_SECURITY_POLICY.md`](compliance/INFORMATION_SECURITY_POLICY.md) | ISMS-aligned information security policy. |
+| [`compliance/STATEMENT_OF_APPLICABILITY.md`](compliance/STATEMENT_OF_APPLICABILITY.md) | ISO 27001 SoA. |
+| [`compliance/ASSET_RISK_REGISTER.md`](compliance/ASSET_RISK_REGISTER.md) | Asset + risk register. |
+| [`compliance/PROCESSING_ACTIVITIES_REGISTER.md`](compliance/PROCESSING_ACTIVITIES_REGISTER.md) | GDPR Article 30 record. |
+| [`compliance/DPIA.md`](compliance/DPIA.md) | Data protection impact assessment. |
+| [`compliance/FRIA.md`](compliance/FRIA.md) | Fundamental rights impact assessment (EU AI Act). |
+| [`compliance/INCIDENT_LOG.md`](compliance/INCIDENT_LOG.md) | Security + privacy incident log. |
+
+## 4. Legal and commercial (`docs/legal/`)
+
+| Document | Purpose |
+| --- | --- |
+| [`legal/TERMS_OF_SERVICE.md`](legal/TERMS_OF_SERVICE.md) | Customer-facing terms of service. |
+| [`legal/PRIVACY_POLICY.md`](legal/PRIVACY_POLICY.md) | Privacy policy. |
+| [`legal/SAAS_AGREEMENT.md`](legal/SAAS_AGREEMENT.md) | SaaS master agreement. |
+| [`legal/DPA.md`](legal/DPA.md) | Data processing addendum. |
+| [`legal/SLA.md`](legal/SLA.md) | Service level agreement. |
+| [`legal/REFUND_CANCELLATION_POLICY.md`](legal/REFUND_CANCELLATION_POLICY.md) | Refund and cancellation policy. |
+| [`legal/COMMERCIAL_LAUNCH_CHECKLIST.md`](legal/COMMERCIAL_LAUNCH_CHECKLIST.md) | Commercial launch + payments compliance pack. |
+
+## 5. iOS / mobile compliance track
+
+The mobile surface is tracked alongside the commercial launch pack. These
+documents cover App Store review readiness, privacy nutrition labelling, and
+mobile-specific acceptance criteria:
+
+- [`legal/PRIVACY_POLICY.md`](legal/PRIVACY_POLICY.md) — privacy disclosures surfaced to App Store reviewers.
+- [`legal/REFUND_CANCELLATION_POLICY.md`](legal/REFUND_CANCELLATION_POLICY.md) — purchase + refund semantics required for iOS IAP review.
+- [`legal/COMMERCIAL_LAUNCH_CHECKLIST.md`](legal/COMMERCIAL_LAUNCH_CHECKLIST.md) — App Store and commercial launch checklist.
+- [`compliance/DPIA.md`](compliance/DPIA.md) and [`compliance/FRIA.md`](compliance/FRIA.md) — privacy + rights review referenced by the mobile release gate.
+- [`PARTNER_ENV_EXECUTION_CHECKLIST.md`](PARTNER_ENV_EXECUTION_CHECKLIST.md) — partner-facing execution checklist including mobile data-node readiness.
+
+## 6. Readiness memos and pilot handoffs
+
+| Document | Purpose |
+| --- | --- |
+| [`PLATFORM_READINESS_MEMO.md`](PLATFORM_READINESS_MEMO.md) | Interdepartmental platform readiness memo. |
+| [`INTERDEPARTMENTAL_COMPLETION_MEMO.md`](INTERDEPARTMENTAL_COMPLETION_MEMO.md) | Launch-item completion memo (items 7–9). |
+| [`FINAL_ACCEPTANCE_READINESS.md`](FINAL_ACCEPTANCE_READINESS.md) | Final acceptance readiness summary. |
+| [`COMPLETENESS_ASSESSMENT.md`](COMPLETENESS_ASSESSMENT.md) | Completeness assessment across all workstreams. |
+| [`MEMO_TO_CLAUDE.md`](MEMO_TO_CLAUDE.md) | Internal engineering memo to the AI assistant. |
+| [`MEMO_TO_VR_STUDIOS_ASSISTANT.md`](MEMO_TO_VR_STUDIOS_ASSISTANT.md) | VR Studios pilot assistant memo. |
+| [`VR_STUDIOS_DATA_NODE.md`](VR_STUDIOS_DATA_NODE.md) | VR Studios data-node architecture. |
+| [`VR_STUDIOS_FINAL_HANDOFF_REPORT.md`](VR_STUDIOS_FINAL_HANDOFF_REPORT.md) | VR Studios final handoff report. |
+
+---
+
+## Paperwork status
+
+All packets above are present in the repository. When a document changes on the
+authoring laptop, update the relevant file in `docs/` and — if its purpose or
+location moves — update this index in the same commit so the README's paperwork
+promise stays honest.


### PR DESCRIPTION
## Summary
- Replaces the outdated `v5.2.0 (Nov 2025)` top-level README with the current `2026-04-22` Sentinel Forge Cognitive AI Orchestration Platform README that lives on the authoring laptop.
- Adds `docs/README.md` — the paperwork index that the new README routes through for engineering-build, SDLC (P1–P9), governance/compliance, legal/commercial, iOS mobile compliance, and readiness memos.
- No code changes; pure documentation alignment so every paperwork packet on the laptop has a single entry point in the repo.

## Paperwork coverage
The index links every existing document under `docs/`:
- Engineering-build and operations (QUICKSTART, API, env setup, release pipeline, etc.)
- SDLC packet — `docs/sdlc/P1-…` through `docs/sdlc/P9-…` plus PRD, system design, API contracts, test strategy.
- Governance / security / compliance — `docs/compliance/` (AI policy, ISMS, SoA, DPIA, FRIA, PAR, incident log, asset risk register).
- Legal and commercial — `docs/legal/` (ToS, privacy, SaaS, DPA, SLA, refund, commercial launch checklist).
- iOS / mobile compliance track — cross-linked from the legal + compliance packets.
- Readiness memos and pilot handoffs (platform readiness, completion memo, final acceptance, VR Studios pack).

## Test plan
- [ ] Repo viewer: confirm top-level `README.md` renders the new Sentinel Forge content with the paperwork line routing through `docs/README.md`.
- [ ] Repo viewer: confirm every link in `docs/README.md` resolves to an existing file in the repo.
- [ ] No CI / code impact expected — docs-only diff.
